### PR TITLE
Add "Ensemble Programming" as default alternative to "Mob Programming"

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -96,7 +96,8 @@
     - Manager
   definition: Used to refer to primary devices.
 - negativeTerm: Mob Programming
-  alternatives: 
+  alternatives:
+    - Ensemble Programming
     - Team Programming
     - Collaborative Programming
   definition: Refers to the individuals working together on the same project


### PR DESCRIPTION
As far as I know, that's the most popular alternative.

cc @nerdydivashanae